### PR TITLE
Updating manifest to latest version

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,10 +6,17 @@ To know more refer https://github.com/sugarlabs/fototoon-activity
 
 ## How To Build
 
+To build this run the following command in terminal
+
+Install the latest version of BaseApp
+```
+flatpak -y --user install org.sugarlabs.BaseApp
+```
+
 ```
 git clone https://github.com/flathub/org.sugarlabs.FotoToon.git
 cd org.sugarlabs.FotoToon
-flatpak -y --user install org.gnome.{Platform,Sdk}//44
+flatpak -y --user install org.gnome.{Platform,Sdk}//45
 flatpak-builder --user --force-clean --install build org.sugarlabs.FotoToon.json
 ```
 

--- a/README.md
+++ b/README.md
@@ -8,15 +8,11 @@ To know more refer https://github.com/sugarlabs/fototoon-activity
 
 To build this run the following command in terminal
 
-Install the latest version of BaseApp
-```
-flatpak -y --user install org.sugarlabs.BaseApp
-```
-
 ```
 git clone https://github.com/flathub/org.sugarlabs.FotoToon.git
 cd org.sugarlabs.FotoToon
-flatpak -y --user install org.gnome.{Platform,Sdk}//45
+flatpak -y --user install flathub org.gnome.{Platform,Sdk}//46
+flatpak -y --user install org.sugarlabs.BaseApp//24.04
 flatpak-builder --user --force-clean --install build org.sugarlabs.FotoToon.json
 ```
 

--- a/fototoon-info.patch
+++ b/fototoon-info.patch
@@ -2,7 +2,7 @@ diff --git a/activity/activity.info b/activity/activity.info
 index 265fce1..496b0f5 100644
 --- a/activity/activity.info
 +++ b/activity/activity.info
-@@ -1,13 +1,22 @@
+@@ -1,13 +1,23 @@
  [Activity]
  name = FotoToon
 -bundle_id = org.eq.FotoToon
@@ -26,4 +26,5 @@ index 265fce1..496b0f5 100644
 +tags = Graphics
 +update_contact = tch@sugarlabs.org
 +developer_name = Sugar Labs Community
++developer_id = org.sugarlabs
 +screenshots = https://raw.githubusercontent.com/sugarlabs/fototoon-activity/master/screenshots/en/1.png https://raw.githubusercontent.com/sugarlabs/fototoon-activity/master/screenshots/en/2.png https://raw.githubusercontent.com/sugarlabs/fototoon-activity/master/screenshots/en/3.png

--- a/org.sugarlabs.FotoToon.json
+++ b/org.sugarlabs.FotoToon.json
@@ -3,7 +3,7 @@
     "base": "org.sugarlabs.BaseApp",
     "base-version": "24.04",
     "runtime": "org.gnome.Platform",
-    "runtime-version": "45",
+    "runtime-version": "46",
     "sdk": "org.gnome.Sdk",
     "separate-locales": false,
     "command": "sugarapp",

--- a/org.sugarlabs.FotoToon.json
+++ b/org.sugarlabs.FotoToon.json
@@ -1,9 +1,9 @@
 {
     "app-id": "org.sugarlabs.FotoToon",
     "base": "org.sugarlabs.BaseApp",
-    "base-version": "23.06",
+    "base-version": "24.04",
     "runtime": "org.gnome.Platform",
-    "runtime-version": "44",
+    "runtime-version": "45",
     "sdk": "org.gnome.Sdk",
     "separate-locales": false,
     "command": "sugarapp",


### PR DESCRIPTION
Manifest updated
runtime-version 45
BaseApp version 24.04
README now include command to install BaseApp before starting the build.